### PR TITLE
Improve KML representation of places

### DIFF
--- a/pleiades/kml/kml_connections_document.pt
+++ b/pleiades/kml/kml_connections_document.pt
@@ -40,8 +40,9 @@
         <ul tal:define="timespan pm/timeSpanAD"><!-- Attributes -->
         <li>ID: <span tal:content="pm/context/getId">PID</span></li>
         <li>In context: <a href="" type=""
-            tal:attributes="href string:${view/alternate_link}"
-            tal:content="view/name">CONTEXT</a></li>
+          tal:attributes="href string:${view/alternate_link}">
+          View <tal:description replace="view/name" /> on the Pleiades website
+        </a></li>
         <li>Names: <span tal:content="pm/appellations">NAMES</span></li>
         </ul>
       <span tal:replace="structure string:]]&gt;" />

--- a/pleiades/kml/kml_document.pt
+++ b/pleiades/kml/kml_document.pt
@@ -34,8 +34,9 @@
       <ul tal:define="timespan folder/timeSpanAD"><!-- Attributes -->
       <li>ID: <span tal:content="folder/context/getId">PID</span></li>
       <li>In context: <a href="" type=""
-          tal:attributes="href string:${folder/alternate_link};"
-          tal:content="view/name">CONTEXT</a></li>
+          tal:attributes="href string:${folder/alternate_link}">
+          View <tal:description tal:replace="view/name" /> on the Pleiades website
+        </a></li>
       <li tal:condition="folder/appellations"
         >Names: <span tal:content="folder/appellations">NAMES</span></li>
       <li tal:condition="features"
@@ -80,11 +81,12 @@
           <li>ID: <span 
             tal:content="string:${view/context/getId}/${pm/context/getId}">PID</span></li>
           <li>In context: <a href="" type=""
-              tal:attributes="href string:${folder/alternate_link};"
-              tal:content="view/name">CONTEXT</a></li>
+            tal:attributes="href string:${folder/alternate_link}">
+            View <tal:description tal:replace="view/name" /> on the Pleiades website
+          </a></li>
           <li><a href="" type=""
             tal:attributes="href string:#${folder/kid};;balloonFlyto"
-            >Fly to parent place</a></li>
+            >Zoom out to view all <tal:text replace="view/name" />locations</a></li>
           </ul>
           <p tal:condition="python:path('pm/geom/precision|nothing') == 'rough'">
           <em>This object is within or partially overlaps the placemark shown.</em>

--- a/pleiades/kml/kml_document.pt
+++ b/pleiades/kml/kml_document.pt
@@ -55,8 +55,30 @@
       <span tal:replace="structure string:]]&gt;" />
     </description>
 
-    <styleUrl>#style-core-normal0</styleUrl>
-
+  <styleUrl>#style-core-normal0</styleUrl>
+  <Placemark tal:attributes="id kid"
+    tal:define="url string:${context/absolute_url}#representativePointField;
+    kid string:${folder/kid}#representativePointField">
+    <name><tal:name replace="folder/name" />: Calculated Representative Point (Centroid)</name>
+    <atom:link tal:attributes="href url"/>
+    <address tal:content="url"/>
+    <description>
+      <span tal:replace="structure string:&lt;![CDATA[" />
+      <p><em>Calculated Representative Point (Centroid) for <tal:name replace="folder/name" /></em></p>
+      <ul><!-- Attributes -->
+        <li>ID: <span tal:content="kid" /></li>
+        <li>In context: <a tal:attributes="href context/absolute_url" type="">View <tal:name replace="folder/name" /> on the Pleiades website.</a></li>
+        <li><a tal:attributes="href string:#${folder/kid};;balloonFlyto" type="">Zoom out to view all <tal:name replace="folder/name" /> locations.</a></li>
+      </ul>
+      <span tal:replace="structure string:]]&gt;"/>
+    </description>
+    <styleUrl>#style-core-0</styleUrl>
+    <Point tal:define="representative_point_lon_lat context/representative-point;
+    representative_point_list python: representative_point_lon_lat.split(', ');
+    representative_point python: representative_point_list[1] + ', ' + representative_point_list[0]">
+      <coordinates tal:content="representative_point"></coordinates>
+    </Point>
+  </Placemark>
   <tal:placemarks tal:repeat="pm folder/features">
 
     <tal:pm_defs
@@ -98,8 +120,8 @@
       </metal:m>
     </tal:pm_defs>
     </tal:placemarks>
-    </Folder>
-    </metal:s>
+  </Folder>
+  </metal:s>
 
   </Document>
 

--- a/pleiades/kml/kml_macros.pt
+++ b/pleiades/kml/kml_macros.pt
@@ -14,7 +14,7 @@
     <metal:macro metal:define-macro="placemark">
 
     <Placemark id="" tal:attributes="id pm/kid">
-      <name tal:content="pm_name">NAME</name>
+      <name><tal:name tal:replace="folder/name" />: <tal:name tal:replace="pm_name" /></name>
       <atom:link tal:attributes="href pm_alternate_link"/>
       <address tal:content="pm_alternate_link"/>
 

--- a/pleiades/kml/kml_neighbors_document.pt
+++ b/pleiades/kml/kml_neighbors_document.pt
@@ -45,8 +45,9 @@
           <ul tal:define="timespan pm/timeSpanAD"><!-- Attributes -->
           <li>ID: <span tal:content="pm/context/getId">PID</span></li>
           <li>In context: <a href="" type=""
-              tal:attributes="href string:${view/alternate_link};"
-              tal:content="view/name">CONTEXT</a></li>
+            tal:attributes="href string:${view/alternate_link};">
+            View <tal:description replace="view/name" /> on the Pleiades website
+          </a></li>
           <li>Names: <span tal:content="pm/appellations">NAMES</span></li>
           </ul>
         <span tal:replace="structure string:]]&gt;" />


### PR DESCRIPTION
See https://github.com/isawnyu/pleiades-gazetteer/issues/276

For the additional `<Placemark>` I did not use the existing macro since we don't really have an object backing up the centroid. This leads to a bit of duplication but IMO it's the best we can do.